### PR TITLE
Fixed handling of relative includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ See [this post](https://forums.flightsimulator.com/t/guide-how-to-extract-base-p
 
 Once you have extracted the MSFS 'base' packages to a location, you only need to point to it the first time using `-s`. 
 
-Example: `-s "c:\MSFS Base\Packages\fs-base-propdefs\Propdefs\1.0\"` .
+Example: `-s "c:\MSFS Base\Packages\fs-base-propdefs\Propdefs\1.0\Common"` .
 
 After that it will use a cache file called `propdefs.cache`, and you dont need to specify `-s` anymore. 
 

--- a/SymbolBank.cs
+++ b/SymbolBank.cs
@@ -31,7 +31,7 @@ namespace spb2xml
         public bool AddSymbolDefinitionFile(string url)
         {
             // extract directory
-            string dirName = new FileInfo(url).DirectoryName;
+            string dirName = new FileInfo(url).Directory.Parent.FullName;
 
             XmlDocument doc = new XmlDocument();
             doc.Load(url);


### PR DESCRIPTION
prop definition files now located in `fs-base-propdefs\Propdefs\1.0\Common` subfolder, but still using as base for includes `fs-base-propdefs\Propdefs\1.0\`.

So in file it appears as:

```
<SymbolInclude
			filename = "Common\propbase.xml"
			id       = "{8042AB84-8003-4ff1-9D4A-6D0D057F00DE}"
			version  = "1,0" />
```

Changes in PR:

* Changed resolution of symbol def element to resolve this includes in proper way
* Updated sample path in README to take into account new location of prop def XML definitions
